### PR TITLE
Add an option to select another mirror

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,9 +6,10 @@ const _cache = new Map()
 module.exports = async function (alias = 'lts_active', opts = {}) {
   const now = opts.now || new Date()
   const cache = opts.cache || _cache
+  const mirror = opts.mirror || 'https://nodejs.org/dist/'
 
   const a = Array.isArray(alias) ? alias : [alias]
-  const versions = await getLatestVersionsByCodename(now, cache)
+  const versions = await getLatestVersionsByCodename(now, cache, mirror)
 
   // Reduce to an object
   const m = a.reduce((m, a) => {
@@ -50,15 +51,15 @@ function getSchedule (cache) {
   }).json()
 }
 
-function getVersions (cache) {
-  return got('https://nodejs.org/dist/index.json', {
+function getVersions (cache, mirror) {
+  return got(mirror.replace(/\/$/, '') + '/index.json', {
     cache
   }).json()
 }
 
-async function getLatestVersionsByCodename (now, cache) {
+async function getLatestVersionsByCodename (now, cache, mirror) {
   const schedule = await getSchedule(cache)
-  const versions = await getVersions(cache)
+  const versions = await getVersions(cache, mirror)
 
   // Composite aliases point to the HEAD for each release line
   const maintained = {}
@@ -67,10 +68,10 @@ async function getLatestVersionsByCodename (now, cache) {
   const lts = {}
 
   const aliases = versions.reduce((obj, ver) => {
-    const { major, minor, patch } = splitVersion(ver.version)
+    const { major, minor, patch, tag } = splitVersion(ver.version)
     const versionName = major !== '0' ? `v${major}` : `v${major}.${minor}`
     const codename = ver.lts ? ver.lts.toLowerCase() : versionName
-    const version = `${major}.${minor}.${patch}`
+    const version = tag !== '' ? `${major}.${minor}.${patch}-${tag}` : `${major}.${minor}.${patch}`
     const s = schedule[versionName]
 
     // Version Object
@@ -79,6 +80,7 @@ async function getLatestVersionsByCodename (now, cache) {
       major,
       minor,
       patch,
+      tag,
       codename,
       versionName,
       start: s && s.start && new Date(s.start),
@@ -147,6 +149,6 @@ async function getLatestVersionsByCodename (now, cache) {
 }
 
 function splitVersion (ver) {
-  const [, major, minor, patch] = /^v([0-9]*)\.([0-9]*)\.([0-9]*)/.exec(ver).map((n) => parseInt(n, 10))
-  return { major, minor, patch }
+  const [, major, minor, patch, tag] = /^v([0-9]*)\.([0-9]*)\.([0-9]*)(?:-([0-9A-Za-z-_]+))?/.exec(ver).map((n, i) => i < 4 ? parseInt(n, 10) : n || '')
+  return { major, minor, patch, tag }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -18,7 +18,7 @@ suite('nv', () => {
     assert.strictEqual(versions[0].versionName, 'v10')
     assert.strictEqual(versions[0].start.toISOString(), '2018-04-24T00:00:00.000Z')
     assert.strictEqual(versions[0].lts.toISOString(), '2018-10-30T00:00:00.000Z')
-    assert.strictEqual(versions[0].maintenance.toISOString(), '2020-04-01T00:00:00.000Z')
+    assert.strictEqual(versions[0].maintenance.toISOString(), '2020-05-19T00:00:00.000Z')
     assert.strictEqual(versions[0].end.toISOString(), '2021-04-30T00:00:00.000Z')
   })
 
@@ -114,5 +114,16 @@ suite('nv', () => {
     assert.strictEqual(versions.length, 2)
     assert.strictEqual(versions[0].major, 10)
     assert.strictEqual(versions[1].major, 12)
+  })
+
+  test('mirror: v8-canary', async () => {
+    const mirror = 'https://nodejs.org/download/v8-canary/'
+    const versions = await nv('v13', { now, mirror })
+    assert.strictEqual(versions.length, 1)
+    assert.strictEqual(versions[0].major, 13)
+    assert.strictEqual(versions[0].minor, 0)
+    assert.strictEqual(versions[0].patch, 0)
+    assert.strictEqual(versions[0].tag, 'v8-canary20191022e5d3472f57')
+    assert.strictEqual(versions[0].versionName, 'v13')
   })
 })


### PR DESCRIPTION
This PR investigates adding a `mirror` option, plus a test using `v8-canary`, an [Experimental Node.js mirror on V8 lkgr](https://github.com/nodejs/node-v8). Mostly a suggestion since I don't know if you are open to changes like this, but was easy to do so I thought I make a PR right away.

In my particular use case I'd like to obtain the latest `v8-canary` build for WebAssembly testing, and having a proper way to do so instead of using some sort of workaround would be great :)