### PR TITLE
Add 'node' alias for nvm compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ For now referenced here until we have a more official doc: https://github.com/no
 - `active`: The newest version in the active but not maintenence mode lines
 - `lts_latest`/`lts/*`: Latest of the LTS lines (`lts/*` for nvm compat)
 - `maintained`: Head of all maintained lines
-- `current`: Newest of all maintained lines
+- `current`/`node`: Newest of all maintained lines (`node` for nvm compat)
 
 **Version Aliases**
 

--- a/index.js
+++ b/index.js
@@ -143,6 +143,9 @@ async function getLatestVersionsByCodename (now, cache) {
   // nvm --lts='lts/*'
   aliases['lts/*'] = aliases.lts_latest
 
+  // nvm 'node'
+  aliases.node = aliases.current
+
   return aliases
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -64,6 +64,12 @@ suite('nv', () => {
     assert.strictEqual(versions[0].major, 12)
     assert.strictEqual(versions[0].codename, 'erbium')
     assert.strictEqual(versions[0].versionName, 'v12')
+
+    const node = await nv('node', { now })
+    assert.strictEqual(node.length, 1)
+    assert.strictEqual(node[0].major, 12)
+    assert.strictEqual(node[0].codename, 'erbium')
+    assert.strictEqual(node[0].versionName, 'v12')
   })
 
   test('maintained', async () => {


### PR DESCRIPTION
This adds the alias `node` for `current` for compatibility with nvm, where `node` "installs the latest version of node".

My use case here is that I'd like to put this library in front of nvm respectively nvm-windows, which don't behave exactly the same, so this would help to achieve better compatibility.