### PR TITLE
fix: do not ignore esm wrap on publish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+!.esm-wrapper.mjs


### PR DESCRIPTION
The addition of a gitignore for `.esm-wrapper.mjs` meant that npm publish also ignored that.  This just excludes it when publishing.  I tested it in a project where we use esm and it fixed the import issue.  Going to fast track this merge.