### PR TITLE
feat: latestOfMajorOnly option to restrict to latest of each major line

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,7 @@ interface Options {
   now?: Date;
   cache?: Map<any, any>;
   mirror?: string;
+  latestOfMajorOnly?: Boolean
 }
 
 interface VersionInfo {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -7,6 +7,7 @@ import nv from '.'
   await nv(['lts_active'], {
     now: new Date(),
     cache: new Map(),
-    mirror: 'http://example.com'
+    mirror: 'http://example.com',
+    latestOfMajorOnly: true
   })
 })()

--- a/test/index.js
+++ b/test/index.js
@@ -132,4 +132,10 @@ suite('nv', () => {
     assert.strictEqual(versions[0].tag, 'v8-canary20191022e5d3472f57')
     assert.strictEqual(versions[0].versionName, 'v13')
   })
+
+  test('latestOfMajorOnly', async () => {
+    const versions = await nv('18.x', { now, latestOfMajorOnly: true })
+    assert.strictEqual(versions.length, 1)
+    assert.strictEqual(versions[0].major, 18)
+  })
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

When you request some aliases or a semver range it returns *all* versions in that range. This option will return just the latest of each major when passed no matter the collection of aliases/versions you pass in.