### PR TITLE
fix!: codename should be null on non-lts (#21)

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ async function getLatestVersionsByCodename (now, cache, mirror) {
   const aliases = versions.reduce((obj, ver) => {
     const { major, minor, patch, tag } = splitVersion(ver.version)
     const versionName = major !== '0' ? `v${major}` : `v${major}.${minor}`
-    const codename = ver.lts ? ver.lts.toLowerCase() : versionName
+    const codename = ver.lts ? ver.lts.toLowerCase() : null
     const version = tag !== '' ? `${major}.${minor}.${patch}-${tag}` : `${major}.${minor}.${patch}`
     const s = schedule[versionName]
 

--- a/test/index.js
+++ b/test/index.js
@@ -177,4 +177,9 @@ suite('nv', () => {
     assert.strictEqual(versions[0].major, 0)
     assert.strictEqual(versions[0].isLts, false)
   })
+
+  test('codename null on non-lts', async () => {
+    const versions = await nv('0.8.0', { now })
+    assert.strictEqual(versions[0].codename, null)
+  })
 })


### PR DESCRIPTION
Fixed #21 but is breaking. All of this will lead up to a 1.0.0 anyway so should be fine to merge now.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
