### PR TITLE
feat!: tag => prerelease and use semver (#20)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ interface VersionInfo {
   major: number;
   minor: number;
   patch: number;
-  tag: string;
+  prerelease?: string[];
   codename: string;
   versionName: string;
   start?: Date;

--- a/index.js
+++ b/index.js
@@ -81,10 +81,9 @@ async function getLatestVersionsByCodename (now, cache, mirror) {
   const lts = {}
 
   const aliases = versions.reduce((obj, ver) => {
-    const { major, minor, patch, tag } = splitVersion(ver.version)
+    const { version, major, minor, patch, prerelease } = semver.parse(ver.version)
     const versionName = major !== '0' ? `v${major}` : `v${major}.${minor}`
     const codename = ver.lts ? ver.lts.toLowerCase() : null
-    const version = tag !== '' ? `${major}.${minor}.${patch}-${tag}` : `${major}.${minor}.${patch}`
     const s = schedule[versionName]
 
     // Version Object
@@ -93,7 +92,7 @@ async function getLatestVersionsByCodename (now, cache, mirror) {
       major,
       minor,
       patch,
-      tag,
+      prerelease,
       codename,
       versionName,
       start: s && s.start && new Date(s.start),
@@ -185,9 +184,4 @@ async function getLatestVersionsByCodename (now, cache, mirror) {
   })
 
   return aliases
-}
-
-function splitVersion (ver) {
-  const [, major, minor, patch, tag] = /^v([0-9]*)\.([0-9]*)\.([0-9]*)(?:-([0-9A-Za-z-_]+))?/.exec(ver).map((n, i) => i < 4 ? parseInt(n, 10) : n || '')
-  return { major, minor, patch, tag }
 }

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -7,7 +7,7 @@ import assert from 'node:assert'
   assert(versions[0].major)
   assert(versions[0].minor)
   assert(versions[0].patch)
-  assert(versions[0].tag)
+  assert(!versions[0].prerelease)
   assert(versions[0].codename)
   assert(versions[0].versionName)
   assert(versions[0].start)

--- a/test/index.js
+++ b/test/index.js
@@ -162,7 +162,7 @@ suite('nv', () => {
     assert.strictEqual(versions[0].major, 13)
     assert.strictEqual(versions[0].minor, 0)
     assert.strictEqual(versions[0].patch, 0)
-    assert.strictEqual(versions[0].tag, 'v8-canary20191022e5d3472f57')
+    assert.deepStrictEqual(versions[0].prerelease, ['v8-canary20191022e5d3472f57'])
     assert.strictEqual(versions[0].versionName, 'v13')
   })
 


### PR DESCRIPTION
`tag` is now `prerelease` which is used in the canary builds. Also uses `semver` instead of the old regex.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
