### PR TITLE
feat: add option to ignore future releases

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,8 @@ interface Options {
   now?: Date;
   cache?: Map<any, any>;
   mirror?: string;
-  latestOfMajorOnly?: Boolean
+  latestOfMajorOnly?: Boolean;
+  ignoreFutureReleases?: Boolean;
 }
 
 interface VersionInfo {

--- a/index.js
+++ b/index.js
@@ -8,9 +8,10 @@ module.exports = async function (alias = 'lts_active', opts = {}) {
   const cache = opts.cache || _cache
   const mirror = opts.mirror || 'https://nodejs.org/dist/'
   const latestOfMajorOnly = opts.latestOfMajorOnly || false
+  const ignoreFutureReleases = opts.ignoreFutureReleases || false
 
   const a = Array.isArray(alias) ? alias : [alias]
-  const versions = await getLatestVersionsByCodename(now, cache, mirror)
+  const versions = await getLatestVersionsByCodename(now, cache, mirror, ignoreFutureReleases)
 
   // Reduce to an object
   let m = a.reduce((m, a) => {
@@ -70,7 +71,7 @@ function getVersions (cache, mirror) {
   }).json()
 }
 
-async function getLatestVersionsByCodename (now, cache, mirror) {
+async function getLatestVersionsByCodename (now, cache, mirror, ignoreFutureReleases) {
   const schedule = await getSchedule(cache)
   const versions = await getVersions(cache, mirror)
 
@@ -110,6 +111,11 @@ async function getLatestVersionsByCodename (now, cache, mirror) {
         zlib: ver.zlib,
         openssl: ver.openssl
       }
+    }
+
+    // This version is from future; completely ignore it (i.e. we may have specified a `now` from the past)
+    if (ignoreFutureReleases && now < v.releaseDate) {
+      return obj
     }
 
     // All versions get added to all

--- a/test/index.js
+++ b/test/index.js
@@ -177,4 +177,20 @@ suite('nv', () => {
     assert.strictEqual(versions[0].major, 0)
     assert.strictEqual(versions[0].isLts, false)
   })
+
+  test('ignoreFutureReleases=false', async () => {
+    const versions = await nv('v8', { now, ignoreFutureReleases: false })
+    assert.strictEqual(versions.length, 1)
+    assert.strictEqual(versions[0].major, 8)
+    assert.strictEqual(versions[0].minor, 17)
+    assert.strictEqual(versions[0].patch, 0)
+  })
+
+  test('ignoreFutureReleases=true', async () => {
+    const versions = await nv('v8', { now, ignoreFutureReleases: true })
+    assert.strictEqual(versions.length, 1)
+    assert.strictEqual(versions[0].major, 8)
+    assert.strictEqual(versions[0].minor, 16)
+    assert.strictEqual(versions[0].patch, 1)
+  })
 })


### PR DESCRIPTION
Add an `ignoreFutureReleases` flag to ignore releases with dates after `now`. This is useful when specifying a `now` in the past (e.g. to ignore an in-flight release, as is currently the case with `v18.20.5`)

Alternatively we could just update the `now` logic to always do this, but that would be a breaking change and half the tests would need to be reworked 😆 😭 

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
