### PR TITLE
feat(cli): expose --latest-of-major-only option

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,44 @@
 
 This repository is managed by the [Package Maintenance Working Group](https://github.com/nodejs/package-maintenance), see [Governance](https://github.com/nodejs/package-maintenance/blob/master/Governance.md).
 
-
-
 ## Usage
 
 ```
 $ npm i @pkgjs/nv
+```
+
+```
+$ npx @pkgjs/nv --help
+
+nv <command>
+
+Commands:
+  nv ls [versions...]  List Node.js versions                     [aliases: show]
+
+Options:
+  --help     Show help                                                 [boolean]
+  --version  Show version number                                       [boolean]
+
+```
+
+```
+$ npx @pkgjs/nv ls --help
+
+nv ls [versions...]
+
+List Node.js versions
+
+Options:
+  --help                  Show help                                    [boolean]
+  --version               Show version number                          [boolean]
+  --mirror                mirror url to load from
+                                    [string] [default: https://nodejs.org/dist/]
+  --pretty-json           Pretty print json
+    [string] [default: pretty print json spaces, default 2 (--no-pretty-json for
+                                                        new line delimted json)]
+  --latest-of-major-only  Only show latest version in each semver major range
+                                                      [boolean] [default: false]
+  --versions                                             [default: "lts_active"]
 ```
 
 ```javascript

--- a/bin/nv
+++ b/bin/nv
@@ -18,10 +18,16 @@ require('yargs')
         defaultDescription: 'pretty print json spaces, default 2 (--no-pretty-json for new line delimted json)',
         description: 'Pretty print json'
       })
+      yargs.option('latest-of-major-only', {
+        type: 'boolean',
+        default: false,
+        description: 'Only show latest version in each semver major range'
+      })
     },
     handler: (argv) => {
       nv(argv.versions, {
-        mirror: argv.mirror
+        mirror: argv.mirror,
+        latestOfMajorOnly: argv.latestOfMajorOnly
       })
         .then(result => {
           result.forEach(r => {

--- a/test/cli.js
+++ b/test/cli.js
@@ -27,4 +27,14 @@ suite('nv cli', () => {
       assert(r.version.startsWith('8.'))
     })
   })
+  test('should only contain the latest of each major', () => {
+    const result = execFileSync(nv, ['ls', '16.x || 18.x', '--no-pretty-json', '--latest-of-major-only'], { cwd: cwd })
+      .toString().trim().split('\n')
+      .map((line) => JSON.parse(line))
+
+    assert(Array.isArray(result))
+    assert.strictEqual(result.length, 2)
+    assert(result[0].version.startsWith('16.'))
+    assert(result[1].version.startsWith('18.'))
+  })
 })


### PR DESCRIPTION
This option was added in #27 but not exposed on the cli. This adds `--latest-of-major-only` and `--no-latest-of-major-only`. Added cli docs while I was in there.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
